### PR TITLE
style: restyles the header and active aesthetic

### DIFF
--- a/src/components/Layout/global.css
+++ b/src/components/Layout/global.css
@@ -71,6 +71,7 @@ a {
   background-color: transparent;
   -webkit-text-decoration-skip: objects;
   color: var(--primary-accent);
+  text-decoration-skip-ink: auto;
 }
 a:active,
 a:hover {

--- a/src/components/MobileMenu/mobilemenu.module.css
+++ b/src/components/MobileMenu/mobilemenu.module.css
@@ -1,10 +1,10 @@
 .menu {
-  --primary-accent: #6219ff;
+  --primary-accent: #6d28d9;
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  background: #6219ff;
+  background: var(--primary-accent);
   z-index: 10;
   overflow: hidden;
   box-shadow: var(--box-shadow-large);
@@ -12,7 +12,7 @@
 
 .header {
   --header-color: #fff;
-  background: #6219ff;
+  background: var(--primary-accent);
   position: relative;
 }
 
@@ -20,12 +20,12 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  padding: 0.5rem 1rem 2rem;
+  padding: 0.5rem 0 1.45rem;
 }
 
 .navigation a {
   color: #fff;
   font-weight: 500;
-  font-size: 3rem;
+  font-size: 1.625rem;
   line-height: 1.5;
 }

--- a/src/components/NavLink/navlink.module.css
+++ b/src/components/NavLink/navlink.module.css
@@ -4,7 +4,7 @@
   text-decoration: none;
   padding: 0.375rem 0.625rem;
   text-decoration: none;
-  margin-left: 0.5rem;
+  margin-left: 0.375rem;
   border-radius: var(--border-radius);
 }
 
@@ -17,6 +17,25 @@
 @media (max-width: 767px) {
   .active {
     text-decoration: underline;
+    text-decoration-skip-ink: auto;
+  }
+
+  .link:after {
+    content: url('data:image/svg+xml,%3Csvg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath fill-rule="evenodd" clip-rule="evenodd" d="M15.3193 6.42654L19.2207 12L15.3193 17.5735L13.6808 16.4265L16.0794 13H6V11H16.0794L13.6808 7.57347L15.3193 6.42654Z" fill="white"%3E%3C/path%3E%3C/svg%3E');
+    line-height: 0;
+  }
+
+  .link:after,
+  .active:after {
+    position: absolute;
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .active:after {
+    content: '\00B7';
+    font-size: 3rem;
   }
 }
 


### PR DESCRIPTION
The mobile menu has been restyled with smaller text. The active link now has a circle next to it and the others have an arrow indicating that it will take them to a separate page.