### PR TITLE
Pinned sidebar content mobile

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,7 +31,7 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              offsetY: `80`,
+              offsetY: `115`,
             },
           },
           `resource-format`,
@@ -85,7 +85,7 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              offsetY: `80`,
+              offsetY: `115`,
             },
           },
           {

--- a/src/components/Footer/footer.module.css
+++ b/src/components/Footer/footer.module.css
@@ -60,6 +60,5 @@
 @media (max-width: 767px) {
   .footer {
     grid-template-columns: 0.5fr 1px 1fr;
-    margin-top: 0;
   }
 }

--- a/src/components/Layout/global.css
+++ b/src/components/Layout/global.css
@@ -38,7 +38,6 @@ body {
 
 article,
 aside,
-details,
 figcaption,
 figure,
 footer,
@@ -46,8 +45,7 @@ header,
 main,
 menu,
 nav,
-section,
-summary {
+section {
   display: block;
 }
 audio,

--- a/src/components/Layout/layout.module.css
+++ b/src/components/Layout/layout.module.css
@@ -1,3 +1,8 @@
+.container,
+.container-fluid {
+  grid-gap: var(--content-grid-gap);
+}
+
 .container {
   margin: 0 auto;
   width: 95%;

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -4,15 +4,38 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 import styles from './sidebar.module.css';
 
-const ConditionalWrapper = ({ children, className, noContextMenu }) => {
+const ConditionalWrapper = ({
+  children,
+  className,
+  noContextMenu,
+  noAccordianClose,
+}) => {
+  const [accordianState, setAccordianState] = useState();
+
+  const handleClick = () => setAccordianState(!accordianState);
   const [title, description, ...content] = children;
+
   return useMediaQuery('(max-width: 767px)') && !noContextMenu ? (
     <>
       {title}
       {description}
-      <details className={styles.accordion}>
-        <summary>Context Menu</summary>
-        {content}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+      <details className={styles.accordion} open={accordianState}>
+        <summary
+          onClick={(e) => {
+            e.preventDefault();
+            handleClick();
+          }}
+        >
+          Context Menu
+        </summary>
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div
+          onClick={() => (noAccordianClose ? undefined : handleClick())}
+          onKeyPress={() => (noAccordianClose ? undefined : handleClick())}
+        >
+          {content}
+        </div>
       </details>
     </>
   ) : (
@@ -30,6 +53,7 @@ const Index = ({
   description,
   searchContext,
   noContextMenu,
+  noAccordianClose,
 }) => {
   const allPosts = data ? data.edges : '';
   const [searchPosts, setSearchPosts] = useState(allPosts);
@@ -38,7 +62,11 @@ const Index = ({
   };
 
   return (
-    <ConditionalWrapper className={className} noContextMenu={noContextMenu}>
+    <ConditionalWrapper
+      className={className}
+      noContextMenu={noContextMenu}
+      noAccordianClose={noAccordianClose}
+    >
       {title &&
         (title === 'Blog' || title === 'Snippets' ? (
           <h1 className={styles.title}>{title}</h1>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,7 +1,26 @@
 import React, { useState } from 'react';
 import Search from '../Search';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 import styles from './sidebar.module.css';
+
+const ConditionalWrapper = ({ children, className }) => {
+  const [title, description, ...content] = children;
+  return useMediaQuery('(max-width: 767px)') ? (
+    <>
+      {title}
+      {description}
+      <details className={styles.accordion}>
+        <summary>Context Menu</summary>
+        {content}
+      </details>
+    </>
+  ) : (
+    <div className={`${className || ''} ${styles.sidebar}`}>
+      <div className={styles.sticky}>{children}</div>
+    </div>
+  );
+};
 
 const Index = ({
   children,
@@ -18,27 +37,27 @@ const Index = ({
   };
 
   return (
-    <div className={`${className || ''} ${styles.sidebar}`}>
-      <div className={styles.sticky}>
-        {title &&
-          (title === 'Blog' || title === 'Snippets' ? (
-            <h1 className={styles.title}>{title}</h1>
-          ) : (
-            <span className={styles.title}>{title}</span>
-          ))}
+    <ConditionalWrapper className={className}>
+      {title &&
+        (title === 'Blog' || title === 'Snippets' ? (
+          <h1 className={styles.title}>{title}</h1>
+        ) : (
+          <span className={styles.title}>{title}</span>
+        ))}
 
-        {description && <p className={styles.description}>{description}</p>}
-        {data && (
-          <div className={styles.bar}>
-            <span>{searchContext}</span>
-            <Search allPosts={allPosts} searchedPosts={searchedPosts} />
-          </div>
-        )}
-        <section className={styles.posts}>
-          {data ? children({ searchPosts }) : children}
-        </section>
-      </div>
-    </div>
+      {description && <p className={styles.description}>{description}</p>}
+
+      {data && (
+        <div className={styles.bar}>
+          <span>{searchContext}</span>
+          <Search allPosts={allPosts} searchedPosts={searchedPosts} />
+        </div>
+      )}
+
+      <section className={styles.posts}>
+        {data ? children({ searchPosts }) : children}
+      </section>
+    </ConditionalWrapper>
   );
 };
 

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -4,9 +4,9 @@ import { useMediaQuery } from '../../hooks/useMediaQuery';
 
 import styles from './sidebar.module.css';
 
-const ConditionalWrapper = ({ children, className }) => {
+const ConditionalWrapper = ({ children, className, noContextMenu }) => {
   const [title, description, ...content] = children;
-  return useMediaQuery('(max-width: 767px)') ? (
+  return useMediaQuery('(max-width: 767px)') && !noContextMenu ? (
     <>
       {title}
       {description}
@@ -29,6 +29,7 @@ const Index = ({
   className,
   description,
   searchContext,
+  noContextMenu,
 }) => {
   const allPosts = data ? data.edges : '';
   const [searchPosts, setSearchPosts] = useState(allPosts);
@@ -37,7 +38,7 @@ const Index = ({
   };
 
   return (
-    <ConditionalWrapper className={className}>
+    <ConditionalWrapper className={className} noContextMenu={noContextMenu}>
       {title &&
         (title === 'Blog' || title === 'Snippets' ? (
           <h1 className={styles.title}>{title}</h1>

--- a/src/components/Sidebar/sidebar.module.css
+++ b/src/components/Sidebar/sidebar.module.css
@@ -19,7 +19,6 @@
 
 .sidebar span {
   display: block;
-  font-weight: 600;
   margin-bottom: 1.45rem;
 }
 
@@ -32,6 +31,12 @@
 
 .bar span {
   margin: 0;
+}
+
+.title,
+.sidebar span,
+.accordion {
+  font-weight: 600;
 }
 
 .title,
@@ -55,5 +60,43 @@
 
   .sticky > section {
     overflow-y: scroll;
+  }
+}
+
+.accordion {
+  position: sticky;
+  top: 70px;
+  background: var(--primary-background);
+  z-index: 5;
+}
+
+.accordion:active {
+  outline: none;
+}
+
+.accordion summary {
+  font-size: 1rem;
+  color: var(--primary-accent);
+  padding: 0 0 0.75rem;
+  outline: none;
+}
+
+.accordion summary + * {
+  padding-top: 1.45rem;
+  max-height: 60vh;
+  overflow-y: scroll;
+}
+
+@media (max-width: 767px) {
+  .title {
+    grid-area: title;
+    margin-bottom: 0;
+  }
+  .description {
+    grid-area: description;
+    margin-bottom: 0;
+  }
+  .accordion {
+    grid-area: context;
   }
 }

--- a/src/components/Sidebar/sidebar.module.css
+++ b/src/components/Sidebar/sidebar.module.css
@@ -82,7 +82,7 @@
 }
 
 .accordion summary + * {
-  padding-top: 1.45rem;
+  padding-top: 0.7rem;
   max-height: 60vh;
   overflow-y: scroll;
 }
@@ -98,5 +98,6 @@
   }
   .accordion {
     grid-area: context;
+    margin-bottom: -0.75rem;
   }
 }

--- a/src/components/TableOfContents/index.js
+++ b/src/components/TableOfContents/index.js
@@ -54,7 +54,7 @@ const TableOfContents = ({ tableOfContents, location, className }) => {
 
   return (
     <>
-      <span>Table of Contents</span>
+      <span className={styles.title}>Table of Contents</span>
       <ul className={`${styles.tableOfContents} ${className || ''}`}>
         {createItems(tableOfContents.items, location, activeHash)}
       </ul>

--- a/src/components/TableOfContents/tableOfContent.module.css
+++ b/src/components/TableOfContents/tableOfContent.module.css
@@ -45,6 +45,11 @@
   font-weight: 600;
 }
 
+.title {
+  display: block;
+  margin-bottom: 1.45rem;
+}
+
 @media (min-width: 768px) {
   .tableOfContents {
     --list-spacing: 0.5rem;

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -55,7 +55,7 @@ const Blog = ({ data, location }) => {
           <Blogpost node={node} key={i} />
         ))}
       </div>
-      <Sidebar title="Blog" description={description}>
+      <Sidebar title="Blog" description={description} noAccordianClose>
         {categories.map(({ category, edges }, index) => {
           const allTags = new Set();
           edges.forEach(({ node }) => {

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -64,7 +64,7 @@ const Blog = ({ data, location }) => {
 
           return (
             <div className={styles.category} key={index}>
-              <span>{category}</span>
+              <span className={styles.categoryTitle}>{category}</span>
               <div className={styles.tags}>
                 {[...allTags].map((tag, i) => (
                   <button

--- a/src/pages/blog.module.css
+++ b/src/pages/blog.module.css
@@ -1,6 +1,5 @@
 .blog {
   display: grid;
-  grid-gap: 2rem;
   grid-template-columns: var(--content-grid-columns);
   grid-template-areas: var(--content-grid-template);
 }

--- a/src/pages/blog.module.css
+++ b/src/pages/blog.module.css
@@ -34,6 +34,12 @@
   color: var(--primary-foreground);
 }
 
+.categoryTitle {
+  display: block;
+  color: var(--primary-accent);
+  margin-bottom: 1.45rem;
+}
+
 .category {
   margin-bottom: 1.45rem;
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -1,6 +1,7 @@
 .homeWrapper {
   --nav-color: var(--primary-background);
   --left-divider: var(--foreground-low);
+  --content-grid-gap: 0;
 }
 
 .home {
@@ -56,6 +57,10 @@
   padding: 0 1rem;
 }
 
+.home footer {
+  margin-top: 0;
+}
+
 @media (min-width: 768px) {
   .homeWrapper {
     --header-background: none;
@@ -106,6 +111,10 @@
 }
 
 @media (max-width: 767px) {
+  .homeWrapper {
+    --content-grid-gap: 0;
+  }
+
   .home {
     grid-template-areas: 'intro' 'timeline' 'footer';
     grid-template-columns: 1fr;

--- a/src/pages/resources.module.css
+++ b/src/pages/resources.module.css
@@ -1,13 +1,8 @@
 .resources {
   width: 100%;
   display: grid;
-  grid-gap: 2rem;
   grid-template-columns: var(--content-grid-columns);
   grid-template-areas: var(--content-grid-template);
-}
-
-.sidebar div section {
-  grid-gap: 0.5rem;
 }
 
 .content {

--- a/src/pages/snippets.module.css
+++ b/src/pages/snippets.module.css
@@ -1,7 +1,6 @@
 .snippets {
   width: 100%;
   display: grid;
-  grid-gap: 2rem;
   grid-template-columns: var(--content-grid-columns);
   grid-template-areas: var(--content-grid-template);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -18,6 +18,7 @@
   --max-layout-width: 1440px;
   --content-grid-template: 'sidebar content padding' 'sidebar footer padding';
   --content-grid-columns: 340px minmax(0, 1fr) 2rem;
+  --content-grid-gap: 2rem;
   --container-padding: 4.5rem;
   --content-x-padding: 1.5rem;
   --content-spacing-left: 10%;
@@ -56,8 +57,9 @@
 @media (max-width: 767px) {
   :root {
     --content-x-padding: 1rem;
-    --content-grid-template: 'sidebar' 'content' 'footer';
+    --content-grid-template: 'title' 'description' 'context' 'content' 'footer';
     --content-grid-columns: 1fr;
+    --content-grid-gap: 1rem;
     --content-width: 100%;
     --content-spacing-left: 0;
   }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -59,7 +59,7 @@
     --content-x-padding: 1rem;
     --content-grid-template: 'title' 'description' 'context' 'content' 'footer';
     --content-grid-columns: 1fr;
-    --content-grid-gap: 1rem;
+    --content-grid-gap: 1.45rem;
     --content-width: 100%;
     --content-spacing-left: 0;
   }

--- a/src/templates/blog-post-hero-layout.js
+++ b/src/templates/blog-post-hero-layout.js
@@ -9,6 +9,8 @@ import Sidebar from '../components/Sidebar';
 import MorePosts from '../components/MorePosts';
 import TableOfContents from '../components/TableOfContents';
 
+import { useMediaQuery } from '../hooks/useMediaQuery';
+
 import styles from './blog-post-hero-layout.module.css';
 
 const BlogPostTemplate = ({ data, location }) => {
@@ -90,25 +92,30 @@ const BlogPostTemplate = ({ data, location }) => {
       <div className={styles.heroWrapper}>
         <Image fluid={featuredSources} />
       </div>
-      <Sidebar className={styles.sidebar} description={description}>
-        {Object.keys(tableOfContents).length !== 0 && (
-          <TableOfContents
-            tableOfContents={tableOfContents}
-            location={location}
-          />
-        )}
-
-        <h4>Written</h4>
-        <div className={styles.written}>
-          <p>{date}</p>
-          <p>{timeToRead} minute read</p>
-        </div>
-
-        <h4>Tags</h4>
-        <div className={styles.tags}>
-          {tags.map((tag, index) => (
-            <div key={index}>{tag}</div>
-          ))}
+      <Sidebar
+        className={styles.sidebar}
+        description={useMediaQuery('(min-width: 768px)') ? description : ''}
+        noContextMenu
+      >
+        {useMediaQuery('(min-width: 768px)') &&
+          Object.keys(tableOfContents).length !== 0 && (
+            <TableOfContents
+              tableOfContents={tableOfContents}
+              location={location}
+            />
+          )}
+        <div className={styles.postMeta}>
+          <div className={styles.written}>
+            <h4>Written</h4>
+            <p>{date}</p>
+            <p>{timeToRead} minute read</p>
+          </div>
+          <div className={styles.tags}>
+            <h4>Tags</h4>
+            {tags.map((tag, index) => (
+              <div key={index}>{tag}</div>
+            ))}
+          </div>
         </div>
       </Sidebar>
       <article className={styles.content}>

--- a/src/templates/blog-post-hero-layout.module.css
+++ b/src/templates/blog-post-hero-layout.module.css
@@ -37,12 +37,12 @@
   composes: content from './blog-post.module.css';
 }
 
+.postMeta {
+  composes: postMeta from './blog-post.module.css';
+}
+
 @media (max-width: 767px) {
   .blogpost {
-    --content-grid-template: 'hero' 'content' 'moreposts' 'footer';
-  }
-
-  .sidebar {
-    display: none;
+    --content-grid-template: 'hero' 'content' 'sidebar' 'moreposts' 'footer';
   }
 }

--- a/src/templates/blog-post-hero-layout.module.css
+++ b/src/templates/blog-post-hero-layout.module.css
@@ -11,7 +11,6 @@
   padding-top: 0;
   grid-template-columns: var(--content-grid-columns);
   grid-template-areas: var(--content-grid-template);
-  grid-gap: 2rem;
 }
 
 .heroWrapper {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -9,6 +9,8 @@ import Sidebar from '../components/Sidebar';
 import MorePosts from '../components/MorePosts';
 import TableOfContents from '../components/TableOfContents';
 
+import { useMediaQuery } from '../hooks/useMediaQuery';
+
 import styles from './blog-post.module.css';
 
 const BlogPostTemplate = ({ data, location }) => {
@@ -31,25 +33,30 @@ const BlogPostTemplate = ({ data, location }) => {
         image={image}
         pathname={location.pathname}
       />
-      <Sidebar className={styles.sidebar} description={description}>
-        {Object.keys(tableOfContents).length !== 0 && (
-          <TableOfContents
-            tableOfContents={tableOfContents}
-            location={location}
-          />
-        )}
-
-        <span>Written</span>
-        <div className={styles.written}>
-          <p>{date}</p>
-          <p>{timeToRead} minute read</p>
-        </div>
-
-        <span>Tags</span>
-        <div className={styles.tags}>
-          {tags.map((tag, index) => (
-            <div key={index}>{tag}</div>
-          ))}
+      <Sidebar
+        className={styles.sidebar}
+        description={useMediaQuery('(min-width: 768px)') ? description : ''}
+        noContextMenu
+      >
+        {useMediaQuery('(min-width: 768px)') &&
+          Object.keys(tableOfContents).length !== 0 && (
+            <TableOfContents
+              tableOfContents={tableOfContents}
+              location={location}
+            />
+          )}
+        <div className={styles.postMeta}>
+          <div className={styles.written}>
+            <h4>Written</h4>
+            <p>{date}</p>
+            <p>{timeToRead} minute read</p>
+          </div>
+          <div className={styles.tags}>
+            <h4>Tags</h4>
+            {tags.map((tag, index) => (
+              <div key={index}>{tag}</div>
+            ))}
+          </div>
         </div>
       </Sidebar>
       <article className={styles.content}>

--- a/src/templates/blog-post.module.css
+++ b/src/templates/blog-post.module.css
@@ -38,10 +38,20 @@
 
 @media (max-width: 767px) {
   .blogpost {
-    --content-grid-template: 'content' 'moreposts' 'footer';
+    --content-grid-template: 'content' 'sidebar' 'moreposts' 'footer';
   }
 
-  .sidebar {
-    display: none;
+  .postMeta {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: 'written tags';
+  }
+
+  .written {
+    grid-area: written;
+  }
+
+  .written p {
+    margin-bottom: 0;
   }
 }


### PR DESCRIPTION
On mobile, sidebar content now sits within an accordion which can be toggled open. On blog post pages the publish date and tags are appended after the content. A couple of extra props can be optionally passed into the sidebar component to control whether we don't want a context menu or don't want the accordion to close when the content is clicked.