### PR TITLE
Latest posts notion api

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,6 @@ module.exports = {
     return config;
   },
   images: {
-    domains: ['i.scdn.co', 'a.ltrbxd.com'],
+    domains: ['i.scdn.co', 'a.ltrbxd.com', 'www.notion.so'],
   },
 };

--- a/src/components/Blogpost/index.jsx
+++ b/src/components/Blogpost/index.jsx
@@ -10,12 +10,15 @@ import Stack from '../Stack';
 
 import s from './blogpost.module.css';
 
-const Blogpost = ({ title, publishedOn, slug, description }) => (
+const Blogpost = ({ title, publishedOn, slug, description, thumbnail }) => (
   <article className={s.blogpost} key={slug}>
     <Link href={`/blog/${slug}`} aria-label={`blog post: ${title}`}>
       <a>
         <Image
-          src={require(`/_posts/${slug}/thumbnail.jpg`).default.src}
+          // Add this conditional here until we move over to Notion
+          src={
+            thumbnail || require(`/_posts/${slug}/thumbnail.jpg`).default.src
+          }
           alt={title}
           width={114}
           height={114}

--- a/src/utils/to-slug.js
+++ b/src/utils/to-slug.js
@@ -1,0 +1,1 @@
+export const toSlug = (title) => title.toLowerCase().replace(/ /g, '-');


### PR DESCRIPTION
ISR currently breaks on the homepage because we need to access the file system to grab the latest posts content. This has now been moved into Notion so we are making requests for the post data instead. Therefore we can now use ISR! So if the Spotify, Readng or Letterboxd data changes we will no longer need to rebuild to see the changes! 👍